### PR TITLE
Support for Sentinel V *.pd0 format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     py_modules=[
         'trdi_adcp_readers.readers',
         'trdi_adcp_readers.pd0.pd0_parser',
+        'trdi_adcp_readers.pd0.pd0_parser_sentinelV',
         'trdi_adcp_readers.pd15.pd0_converters'
     ],
     scripts=['scripts/convert_trdi.py'],

--- a/trdi_adcp_readers/__init__.py
+++ b/trdi_adcp_readers/__init__.py
@@ -1,0 +1,3 @@
+import readers
+import pd0
+import pd15

--- a/trdi_adcp_readers/pd0/__init__.py
+++ b/trdi_adcp_readers/pd0/__init__.py
@@ -1,2 +1,2 @@
-
-
+import pd0_parser
+import pd0_parser_sentinelV

--- a/trdi_adcp_readers/pd0/pd0_parser_sentinelV.py
+++ b/trdi_adcp_readers/pd0/pd0_parser_sentinelV.py
@@ -374,3 +374,36 @@ def parse_pd0_bytearray(pd0_bytes):
             print 'No parser found for header %d' % (header_id,)
 
     return data
+
+
+def get_pd0metadata(D):
+    """
+    Gets additional instrument setup information from
+    the fixed leader data.
+    """
+    # Set the maps for the relevant bytes (TRDI Sentinel V manual Table 37).
+    d_system_configuration_LSB = {'xxxxx010':'Sentinel V100 (300 kHz)',
+                                  'xxxxx011':'Sentinel V50 (500 kHz)',
+                                  'xxxxx100':'Sentinel V20 (1000 kHz)',
+                                  '0xxxxxxx':'downward-looking',
+                                  '1xxxxxxx':'upward-looking'}
+    d_system_configuration_MSB = {'0100xxxx':'4-beam Janus',
+                                  '0101xxxx':'5-beam Janus'}
+
+    d_coord_trans = {'':'',
+                     '':'',
+                     '':'',
+                     'xxxxxxx1':'bin mapping was used'}
+    metadata_maps = {
+        ('system_configuration_LSB'):d_system_configuration_LSB,
+        ('system_configuration_MSB'):d_system_configuration_MSB,
+        ('coordinate_transformation_descriptors'):d_coord_trans,
+    }
+
+    # Read metadata from fixed leader.
+    dFL = D['fixed_leader']
+    for k in dFL.iterkeys():
+        if dFL[k] in metadata_maps.keys():
+            dmap = metadata_maps[k]
+
+

--- a/trdi_adcp_readers/pd0/pd0_parser_sentinelV.py
+++ b/trdi_adcp_readers/pd0/pd0_parser_sentinelV.py
@@ -1,0 +1,376 @@
+import struct
+from datetime import datetime
+
+
+def unpack_bytes(pd0_bytes, data_format_tuples, offset=0):
+    data = {}
+    for fmt in data_format_tuples:
+        try:
+            struct_offset = offset+fmt[2]
+            size = struct.calcsize(fmt[1])
+            data_bytes = buffer(pd0_bytes, struct_offset, size)
+            data[fmt[0]] = (
+                struct.unpack(fmt[1], data_bytes)[0]
+            )
+        except:
+            print('Error parsing %s with the arguments '
+                  '%s, offset:%d size:%d' % (fmt[0], fmt[1],
+                                             struct_offset, size))
+
+    return data
+
+
+def parse_fixed_header(pd0_bytes):
+    """
+    Parses the fixed part of the header (up to byte #6).
+    TRDI Sentinel V manual, p. 250.
+    """
+    header_data_format = (
+        ('id', 'B', 0),
+        ('data_source', 'B', 1),
+        ('number_of_bytes', '<H', 2),
+        ('spare', 'B', 4),
+        ('number_of_data_types', 'B', 5)
+    )
+
+    return unpack_bytes(pd0_bytes, header_data_format)
+
+
+def parse_address_offsets(pd0_bytes, num_datatypes, offset=6):
+    """
+    Parse address offsets (in bytes) for each variable.
+    This information is in the header, but changes with
+    instrument configuration.
+    TRDI Sentinel V manual, p. 250.
+    """
+    address_data = []
+    for bytes_start in xrange(offset, offset+(num_datatypes * 2), 2):
+        data = (
+            struct.unpack_from('<H',
+                               buffer(pd0_bytes, bytes_start, 2))[0]
+        )
+        address_data.append(data)
+
+    return address_data
+
+
+def parse_fixed_leader(pd0_bytes, offset, data, format='sentinelV'):
+    """
+    Parses the variables that do not change with time since
+    the start of deployment. The format depends on the type
+    of *.pd0 file (Workhorse or Sentinel V). This format
+    follows Table 37 on the TRDI Sentinel V manual, p. 251-255.
+    """
+    fixed_leader_format = (
+        ('id', '<H', 0),
+        ('cpu_firmware_version', 'B', 2),
+        ('cpu_firmware_revision', 'B', 3),
+        ('system_configuration_LSB', 'B', 4), # Identifies model and beam orientation (up/down).
+        ('system_configuration_MSB', 'B', 5), # 4 or 5 beam Janus.
+        ('simulation_data_flag', 'B', 6),
+        ('lag_length', 'B', 7),
+        ('number_of_beams', 'B', 8),
+        ('number_of_cells', 'B', 9),
+        ('pings_per_ensemble', '<H', 10),
+        ('depth_cell_length', '<H', 12),
+        ('blank_after_transmit', '<H', 14),
+        ('signal_processing_mode', 'B', 16),
+        ('low_correlation_threshold', 'B', 17),
+        ('number_of_code_repetitions', 'B', 18),
+        ('minimum_percentage_water_profile_pings', 'B', 19),
+        ('error_velocity_threshold', '<H', 20),
+        ('minutes', 'B', 22),
+        ('seconds', 'B', 23),
+        ('hundredths', 'B', 24),
+        ('coordinate_transformation_process', 'B', 25),
+        ('heading_alignment', '<H', 26),
+        ('heading_bias', '<H', 28),
+        ('sensor_source', 'B', 30),
+        ('sensor_available', 'B', 31),
+        ('bin_1_distance', '<H', 32),
+        ('transmit_pulse_length', '<H', 34),
+        ('starting_depth_cell', 'B', 36),
+        ('ending_depth_cell', 'B', 37),
+        ('false_target_threshold', 'B', 38),
+        ('spare', 'B', 39),
+        ('transmit_lag_distance', '<H', 40),
+        ('spare', '<Q', 42), #* Sentinel V manual marks this field as 'spare'.
+        ('system_bandwidth', '<H', 50),
+        ('system_power', 'B', 52),
+        ('spare', 'B', 53),
+        ('serial_number', '<I', 54),
+        ('beam_angle', 'B', 58),
+        ('spare', 'B', 59) #* Sentinel V manual marks this field as 'spare'.
+        )
+
+    return unpack_bytes(pd0_bytes, fixed_leader_format, offset)
+
+
+def parse_variable_leader(pd0_bytes, offset, data):
+    variable_leader_format = (
+        ('id', '<H', 0),
+        ('ensemble_number', '<H', 2),
+        ('rtc_year', 'B', 4),
+        ('rtc_month', 'B', 5),
+        ('rtc_day', 'B', 6),
+        ('rtc_hour', 'B', 7),
+        ('rtc_minute', 'B', 8),
+        ('rtc_second', 'B', 9),
+        ('rtc_hundredths', 'B', 10),
+        ('ensemble_roll_over', 'B', 11),
+        ('bit_result', '<H', 12),
+        ('speed_of_sound', '<H', 14),
+        ('depth_of_transducer', '<H', 16),
+        ('heading', '<H', 18),
+        ('pitch', '<h', 20),
+        ('roll', '<h', 22),
+        ('salinity', '<H', 24),
+        ('temperature', '<h', 26),
+        ('mpt_minutes', 'B', 28),
+        ('mpt_seconds', 'B', 29),
+        ('mpt_hundredths', 'B', 30),
+        ('heading_standard_deviation', 'B', 31),
+        ('pitch_standard_deviation', 'B', 32),
+        ('roll_standard_deviation', 'B', 33),
+        ('transmit_current', 'B', 34),
+        ('transmit_voltage', 'B', 35),
+        ('ambient_temperature', 'B', 36),
+        ('pressure_positive', 'B', 37),
+        ('pressure_negative', 'B', 38),
+        ('attitude_temperature', 'B', 39),
+        ('attitude', 'B', 40),
+        ('contamination_sensor', 'B', 41),
+        ('error_status_word', '<I', 42),
+        ('reserved', '<H', 46),
+        ('pressure', '<I', 48),
+        ('pressure_variance', '<I', 52),
+        ('spare', 'B', 56),
+        ('rtc_y2k_century', 'B', 57),
+        ('rtc_y2k_year', 'B', 58),
+        ('rtc_y2k_month', 'B', 59),
+        ('rtc_y2k_day', 'B', 60),
+        ('rtc_y2k_hour', 'B', 61),
+        ('rtc_y2k_minute', 'B', 62),
+        ('rtc_y2k_seconds', 'B', 63),
+        ('rtc_y2k_hundredths', 'B', 64)
+    )
+
+    variable_data = unpack_bytes(pd0_bytes, variable_leader_format, offset)
+    data['timestamp'] = datetime(
+        variable_data['rtc_year'] + 2000,
+        variable_data['rtc_month'],
+        variable_data['rtc_day'],
+        variable_data['rtc_hour'],
+        variable_data['rtc_minute'],
+        variable_data['rtc_second'],
+        variable_data['rtc_hundredths']
+    )
+    return variable_data
+
+
+def parse_per_cell_per_beam(pd0_bytes, offset,
+                            number_of_cells, number_of_beams,
+                            struct_format, debug=False):
+    """
+    Parses fields that are stored in serial cells and beams
+    structures.
+
+    Returns an array of cell readings where each reading is an
+    array containing the value at that beam.
+    """
+
+    data_size = struct.calcsize(struct_format)
+    data = []
+    for cell in xrange(0, number_of_cells):
+        cell_start = offset + cell*number_of_beams*data_size
+        cell_data = []
+        for field in xrange(0, number_of_beams):
+            field_start = cell_start + field*data_size
+            data_bytes = buffer(pd0_bytes, field_start, data_size)
+            field_data = (
+                struct.unpack(struct_format,
+                              data_bytes)[0]
+            )
+            if debug:
+                print 'Bytes: %s, Data: %s' % (data_bytes, field_data)
+            cell_data.append(field_data)
+        data.append(cell_data)
+
+    return data
+
+
+def parse_velocity(pd0_bytes, offset, data):
+    velocity_format = (
+        ('id', '<H', 0),
+    )
+
+    velocity_data = unpack_bytes(pd0_bytes, velocity_format, offset)
+    offset += 2  # Move past id field
+    velocity_data['data'] = parse_per_cell_per_beam(
+        pd0_bytes,
+        offset,
+        data['fixed_leader']['number_of_cells'],
+        data['fixed_leader']['number_of_beams'],
+        '<h'
+    )
+
+    return velocity_data
+
+
+def parse_correlation(pd0_bytes, offset, data):
+    correlation_format = (
+        ('id', '<H', 0),
+    )
+
+    correlation_data = unpack_bytes(pd0_bytes, correlation_format, offset)
+    offset += 2
+    correlation_data['data'] = parse_per_cell_per_beam(
+        pd0_bytes,
+        offset,
+        data['fixed_leader']['number_of_cells'],
+        data['fixed_leader']['number_of_beams'],
+        'B'
+    )
+
+    return correlation_data
+
+
+def parse_echo_intensity(pd0_bytes, offset, data):
+    echo_intensity_format = (
+        ('id', '<H', 0),
+    )
+
+    echo_intensity_data = unpack_bytes(pd0_bytes,
+                                       echo_intensity_format, offset)
+    offset += 2
+    echo_intensity_data['data'] = parse_per_cell_per_beam(
+        pd0_bytes,
+        offset,
+        data['fixed_leader']['number_of_cells'],
+        data['fixed_leader']['number_of_beams'],
+        'B'
+    )
+
+    return echo_intensity_data
+
+
+def parse_percent_good(pd0_bytes, offset, data):
+    percent_good_format = (
+        ('id', '<H', 0),
+    )
+
+    percent_good_data = unpack_bytes(pd0_bytes, percent_good_format, offset)
+    offset += 2
+    percent_good_data['data'] = parse_per_cell_per_beam(
+        pd0_bytes,
+        offset,
+        data['fixed_leader']['number_of_cells'],
+        data['fixed_leader']['number_of_beams'],
+        'B'
+    )
+
+    return percent_good_data
+
+
+def parse_status(pd0_bytes, offset, data):
+    status_format = (
+        ('id', '<H', 0)
+    )
+
+    status_data = unpack_bytes(pd0_bytes, status_format, offset)
+    offset += 2
+    status_data['data'] = parse_per_cell_per_beam(
+        pd0_bytes,
+        offset,
+        data['fixed_leader']['number_of_cells'],
+        data['fixed_leader']['number_of_beams'],
+        'B'
+    )
+
+    return status_data
+
+
+def parse_bottom_track(pd0_bytes, offset, data):
+    bottom_track_format = (
+        ('id', '<H', 0),
+        ('pings_per_ensemble', '<H', 2),
+        ('delay_before_reaquire', '<H', 4),
+        ('correlation_magnitude_minimum', 'B', 6),
+        ('evaluation_amplitude_minimum', 'B', 7),
+        ('percent_good_minimum', 'B', 8),
+        ('bottom_track_mode', 'B', 9),
+        ('error_velocity_maximum', '<H', 10)
+    )
+
+    bottom_track_data, data_size = unpack_bytes(pd0_bytes,
+                                                bottom_track_format, offset)
+    offset += data_size
+    # Plan to implement as needed
+    raise NotImplementedError()
+
+
+def ChecksumError(Exception):
+    """
+    Raised when an invalid checksum is found
+    """
+    def __init__(self, calc_checksum, given_checksum):
+        self.calc_checksum = calc_checksum
+        self.given_checksum = given_checksum
+
+    def __str__(self):
+        return 'Calculated %d, Given: %d'
+
+
+def validate_checksum(pd0_bytes, offset):
+    calc_checksum = sum(pd0_bytes[:offset]) & 0xFFFF
+    given_checksum = struct.unpack('<H', buffer(pd0_bytes, offset, 2))[0]
+
+    if calc_checksum != given_checksum:
+        raise ChecksumError(calc_checksum, given_checksum)
+
+
+output_data_parsers = {
+    0x0000: ('fixed_leader', parse_fixed_leader),
+    0x0080: ('variable_leader', parse_variable_leader),
+    0x0100: ('velocity', parse_velocity),
+    0x0200: ('correlation', parse_correlation),
+    0x0300: ('echo_intensity', parse_echo_intensity),
+    0x0400: ('percent_good', parse_percent_good),
+    0x0500: ('status', parse_status),
+    0x0600: ('bottom_track', parse_bottom_track)
+}
+
+
+def parse_pd0_bytearray(pd0_bytes):
+    """
+    This is the main parsing loop. It uses output_data_parsers
+    to determine what functions to run given a specified offset and header ID at that offset.
+
+    Returns a dictionary of values parsed out into Python types.
+    """
+
+    data = {}
+
+    # Read in header
+    data['header'] = parse_fixed_header(pd0_bytes)
+
+    # Run checksum
+    validate_checksum(pd0_bytes, data['header']['number_of_bytes'])
+
+    data['header']['address_offsets'] = (
+        parse_address_offsets(pd0_bytes,
+                              data['header']['number_of_data_types'])
+    )
+
+    for offset in data['header']['address_offsets']:
+        header_id = struct.unpack('<H', buffer(pd0_bytes, offset, 2))[0]
+        if header_id in output_data_parsers:
+            key = output_data_parsers[header_id][0]
+            parser = output_data_parsers[header_id][1]
+            data[key] = (
+                parser(pd0_bytes, offset, data)
+            )
+        else:
+            print 'No parser found for header %d' % (header_id,)
+
+    return data

--- a/trdi_adcp_readers/pd15/__init__.py
+++ b/trdi_adcp_readers/pd15/__init__.py
@@ -1,1 +1,1 @@
-
+import pd0_converters

--- a/trdi_adcp_readers/readers.py
+++ b/trdi_adcp_readers/readers.py
@@ -36,13 +36,14 @@ def read_PD15_string(string, return_pd0=False):
 
 def read_PD0_file(path, header_lines=0, return_pd0=False, format='workhorse'):
     pd0_bytes = bytearray()
+    data = []
     with open(path, 'rb') as f:
         for i in xrange(0, header_lines):
             f.readline()
 
         pd0_bytes = bytearray(f.read())
 
-    data = read_PD0_bytes(pd0_bytes, return_pd0=return_pd0, format=format)
+    data.append(read_PD0_bytes(pd0_bytes, return_pd0=return_pd0, format=format))
 
     if return_pd0:
         return data, pd0_bytes
@@ -55,6 +56,8 @@ def read_PD0_bytes(pd0_bytes, return_pd0=False, format='workhorse'):
         data = parse_pd0_bytearray(pd0_bytes)
     elif format=='sentinelV':
         data = parse_sentinelVpd0_bytearray(pd0_bytes)
+    else:
+        raise pd0FormatError
 
     if return_pd0:
         return data, pd0_bytes
@@ -67,3 +70,9 @@ def inspect_PD0_file(path, format='sentinelV'):
     and organizes them in a table.
     """
     raise NotImplementedError()
+
+
+class pd0FormatError(Exception):
+    """Raised when the input *.pd0 format is unknown"""
+    print("Unknown *.pd0 format.")
+    pass

--- a/trdi_adcp_readers/readers.py
+++ b/trdi_adcp_readers/readers.py
@@ -34,7 +34,7 @@ def read_PD15_string(string, return_pd0=False):
         return data
 
 
-def read_PD0_file(path, header_lines=0, return_pd0=False):
+def read_PD0_file(path, header_lines=0, return_pd0=False, format='workhorse'):
     pd0_bytes = bytearray()
     with open(path, 'rb') as f:
         for i in xrange(0, header_lines):
@@ -42,10 +42,7 @@ def read_PD0_file(path, header_lines=0, return_pd0=False):
 
         pd0_bytes = bytearray(f.read())
 
-    if format=='workhorse':
-        data = parse_pd0_bytearray(pd0_bytes)
-    elif format='sentinelV':
-        data = parse_sentinelVpd0_bytearray(pd0_bytes)
+    data = read_PD0_bytes(pd0_bytes, return_pd0=return_pd0, format=format)
 
     if return_pd0:
         return data, pd0_bytes
@@ -56,10 +53,17 @@ def read_PD0_file(path, header_lines=0, return_pd0=False):
 def read_PD0_bytes(pd0_bytes, return_pd0=False, format='workhorse'):
     if format=='workhorse':
         data = parse_pd0_bytearray(pd0_bytes)
-    elif format='sentinelV':
+    elif format=='sentinelV':
         data = parse_sentinelVpd0_bytearray(pd0_bytes)
 
     if return_pd0:
         return data, pd0_bytes
     else:
         return data
+
+def inspect_PD0_file(path, format='sentinelV'):
+    """
+    Fetches and organizes several metadata on instrument setup
+    and organizes them in a table.
+    """
+    raise NotImplementedError()

--- a/trdi_adcp_readers/readers.py
+++ b/trdi_adcp_readers/readers.py
@@ -1,4 +1,6 @@
 import numpy as np
+from pandas import Timedelta
+from xarray import IndexVariable, DataArray, Dataset
 from trdi_adcp_readers.pd0.pd0_parser_sentinelV import (ChecksumError,
                                                         ReadChecksumError,
                                                         ReadHeaderError)
@@ -8,7 +10,7 @@ from trdi_adcp_readers.pd15.pd0_converters import (
 )
 from trdi_adcp_readers.pd0.pd0_parser import parse_pd0_bytearray
 from trdi_adcp_readers.pd0.pd0_parser_sentinelV import parse_sentinelVpd0_bytearray
-from IPython import embed
+# from IPython import embed
 
 
 def read_PD15_file(path, header_lines=0, return_pd0=False):
@@ -39,25 +41,163 @@ def read_PD15_string(string, return_pd0=False):
         return data
 
 
-def ensdict2xarray(ensdict):
+def ensembles2dataset(ensdict, dsattrs={}, verbose=False, print_every=1000):
     """
     Convert a dictionary of ensembles into an xarray Dataset object.
     """
+    mms2ms = 1e-3
     fbadens = np.array(ensdict)==None
     nt = len(ensdict) - np.sum(fbadens)
-    nz = ensdict[0]['fixed_leader_janus']['number_of_cells']
-    sk = np.ma.ones((nz, nt)) # Beam vels stored in mm/s
-                                              # as int64 to save memory.
-    b5 = sk.copy()
+    n=0
+    ensdict0 = None
+    while ensdict0 is None:
+        ensdict0 = ensdict[n]
+        n+=1
+    nz = ensdict0['fixed_leader_janus']['number_of_cells']
+    sk = np.ma.zeros((nz, nt))*np.nan # Beam vels stored in mm/s
+                                      # as int64 to save memory.
+    b1, b2, b3, b4 = sk.copy(), sk.copy(), sk.copy(), sk.copy()
+    sk0 = np.ma.zeros(nt)*np.nan
+    skt = np.ma.zeros(nt, dtype=object)*np.nan
+    cor1, cor2, cor3, cor4 = sk.copy(), sk.copy(), sk.copy(), sk.copy()
+    int1, int2, int3, int4 = sk.copy(), sk.copy(), sk.copy(), sk.copy()
+    b5, cor5, int5 = sk.copy(), sk.copy(), sk.copy()
+    heading, pitch, roll = sk0.copy(), sk0.copy(), sk0.copy()
+    tjanus = []
+
     ensdict = np.array(ensdict)[~fbadens]
     ensdict = ensdict.tolist()
     n=0
     for ensarr in ensdict:
+        tjanus.append(ensarr['timestamp'])
+        heading[n] = ensarr['variable_leader_janus']['heading']
+        pitch[n] = ensarr['variable_leader_janus']['pitch']
+        roll[n] = ensarr['variable_leader_janus']['roll']
+        vjanus = ensarr['velocity_janus']['data']
+        b1[:, n] = vjanus[:, 0]
+        b2[:, n] = vjanus[:, 1]
+        b3[:, n] = vjanus[:, 2]
+        b4[:, n] = vjanus[:, 3]
         b5[:, n] = ensarr['velocity_beam5']['data'].squeeze()
-        if not n%1000: print(n)
-        n+=1
+        corjanus = ensarr['correlation_janus']['data']
+        cor1[:, n] = corjanus[:, 0]
+        cor2[:, n] = corjanus[:, 1]
+        cor3[:, n] = corjanus[:, 2]
+        cor4[:, n] = corjanus[:, 3]
+        cor5[:, n] = ensarr['correlation_beam5']['data'].squeeze()
+        intjanus = ensarr['echo_intensity_janus']['data']
+        int1[:, n] = intjanus[:, 0]
+        int2[:, n] = intjanus[:, 1]
+        int3[:, n] = intjanus[:, 2]
+        int4[:, n] = intjanus[:, 3]
+        int5[:, n] = ensarr['echo_intensity_beam5']['data'].squeeze()
 
-    return b5
+        n+=1
+        if verbose and not n%print_every: print(n)
+
+    fixj = ensdict0['fixed_leader_janus']
+    fix5 = ensdict0['fixed_leader_beam5']
+
+    # Add ping offset to get beam 5's timestamps.
+    dt5 = fix5['ping_offset_time'] # In milliseconds.
+    dt5 = np.array(Timedelta(dt5, unit='ms'))
+    t5 = tjanus + dt5
+
+    th = fixj['beam_angle']
+    assert th==25 # Always 25 degrees.
+    th = th*np.pi/180.
+    Cth = np.cos(th)
+
+    # Construct along-beam/vertical axes.
+    cm2m = 1e-2
+    r1janus = fixj['bin_1_distance']*cm2m
+    r1b5 = fix5['bin_1_distance']*cm2m
+    ncj = fixj['number_of_cells']
+    nc5 = fix5['number_of_cells']
+    lcj = fixj['depth_cell_length']*cm2m
+    lc5 = fix5['depth_cell_length']*cm2m
+    Lj = ncj*lcj # Distance from center of bin 1 to the center of last bin (Janus).
+    L5 = nc5*lc5 # Distance from center of bin 1 to the center of last bin (beam 5).
+
+    rb = r1janus + np.arange(0, Lj, lcj) # Distance from xducer head
+                                         # (Janus).
+    zab = Cth*rb                         # Vertical distance from xducer head
+                                         # (Janus).
+    zab5 = r1b5 + np.arange(0, L5, lc5)  # Distance from xducer head, also
+                                         # depth for the vertical beam.
+
+    rb = IndexVariable('z', rb, attrs={'units':'meters', 'long_name':"along-beam distance from the xducer's face to the center of the bins, for beams 1-4 (Janus)"})
+    zab = IndexVariable('z', zab, attrs={'units':'meters', 'long_name':"vertical distance from the instrument's head to the center of the bins, for beams 1-4 (Janus)"})
+    zab5 = IndexVariable('z', zab5, attrs={'units':'meters', 'long_name':"vertical distance from xducer face to the center of the bins, for beam 5 (vertical)"})
+    time = IndexVariable('time', tjanus, attrs={'long_name':'timestamp for beams 1-4 (Janus)'})
+    time5 = IndexVariable('time', t5, attrs={'long_name':'timestamp for beam 5 (vertical)'})
+
+    coords0 = [('time', time)]
+    coords = [('z', zab), ('time', time)]
+    coords5 = [('z5', zab5), ('time5', time5)]
+    dims = ['z', 'time']
+    dims0 = ['time']
+
+    # Convert velocities to m/s.
+    b1, b2, b3, b4, b5 = b1*mms2ms, b2*mms2ms, b3*mms2ms, b4*mms2ms, b5*mms2ms
+
+    # Scale heading, pitch and roll. Sentinel V manual, p. 259.
+    phisc = 0.01
+    heading *= phisc
+    pitch *= phisc
+    roll *= phisc
+
+    arrs = (b1, b2, b3, b4, b5,
+            cor1, cor2, cor3, cor4, cor5,
+            int1, int2, int3, int4, int5,
+            heading, pitch, roll)
+            # pressure, temperature, salinity, soundspeed)
+    long_names = ('Beam 1 velocity', 'Beam 2 velocity',
+             'Beam 3 velocity', 'Beam 4 velocity',
+             'Beam 5 velocity',
+             'Beam 1 correlation', 'Beam 2 correlation',
+             'Beam 3 correlation', 'Beam 4 correlation',
+             'Beam 5 correlation',
+             'Beam 1 echo amplitude', 'Beam 2 echo amplitude',
+             'Beam 3 echo amplitude', 'Beam 4 echo amplitude',
+             'Beam 5 echo amplitude',
+             'heading', 'pitch', 'roll')
+    units = ('m/s, positive toward xducer face',
+             'm/s, positive toward xducer face',
+             'm/s, positive toward xducer face',
+             'm/s, positive toward xducer face',
+             'm/s, positive toward xducer face',
+             'no units', 'no units', 'no units', 'no units',
+             'no units',
+             'decibels', 'decibels', 'decibels', 'decibels',
+             'decibels',
+             'degrees', 'degrees', 'degrees')
+    names = ('b1', 'b2', 'b3', 'b4', 'b5',
+             'cor1', 'cor2', 'cor3', 'cor4', 'cor5',
+             'int1', 'int2', 'int3', 'int4', 'int5',
+             'phi1', 'phi2', 'phi3')
+    data_vars = {}
+    for arr,name,long_name,unit in zip(arrs,names,long_names,units):
+
+        if 'Beam5' in long_name:
+            coordsn = coords5
+            dimsn = dims
+        elif 'phi' in name:
+            coordsn = coords0
+            dimsn = dims0
+        else:
+            coordsn = coords
+            dimsn = dims
+
+        da = DataArray(arr, coords=coordsn, dims=dimsn, attrs=dict(units=unit, long_name=long_name))
+        data_vars.update({name:da})
+
+    allcoords = {'rb':rb} # Along-beam distance for slanted beams.
+    allcoords.update(coords)
+    allcoords.update(coords5)
+    ds = Dataset(data_vars=data_vars, coords=allcoords, attrs=dsattrs)
+
+    return ds
 
 
 def read_PD0_file(path, header_lines=0, return_pd0=False, all_ensembles=True,
@@ -78,9 +218,9 @@ def read_PD0_file(path, header_lines=0, return_pd0=False, all_ensembles=True,
     ret = pd0reader(pd0_bytes, return_pd0=return_pd0, format=format, **kwread)
 
     if return_pd0:
-        data, BAD_ENS, fbad_ens, errortype_count, pd0_bytes = ret
+        data, fixed_attrs, BAD_ENS, fbad_ens, errortype_count, pd0_bytes = ret
     else:
-        data, BAD_ENS, fbad_ens, errortype_count = ret
+        data, fixed_attrs, BAD_ENS, fbad_ens, errortype_count = ret
 
     if verbose:
         nens = len(data)
@@ -98,24 +238,23 @@ def read_PD0_file(path, header_lines=0, return_pd0=False, all_ensembles=True,
     # Note that these timestamps indicate the Janus' (i.e., beams 1-4) pings,
     # which will not necessarily be the same as the vertical beam's timestamp.
     t = np.array([ens['timestamp'] for ens in data if ens is not None])
-    # t5 = np.array([ens['timestamp5'] for ens in data if ens is not None])
 
     if debug:
         if return_pd0:
-            ret = data, t, BAD_ENS, fbad_ens, errortype_count, pd0_bytes
+            ret = data, t, fixed_attrs, BAD_ENS, fbad_ens, errortype_count, pd0_bytes
         else:
-            ret = data, t, BAD_ENS, fbad_ens, errortype_count
+            ret = data, t, fixed_attrs, BAD_ENS, fbad_ens, errortype_count
     else:
         if return_pd0:
-            ret = data, t, pd0_bytes
+            ret = data, t, fixed_attrs, pd0_bytes
         else:
-            ret = data, t
+            ret = data, t, fixed_attrs
 
     return ret
 
 
 def read_PD0_bytes_ensembles(PD0_BYTES, return_pd0=False, headerid='\x7f\x7f',
-                             format='workhorse',
+                             format='sentinel',
                              verbose=True, print_every=1000):
     """
     Finds the hex positions in the bytearray that identify the header of each
@@ -159,23 +298,25 @@ def read_PD0_bytes_ensembles(PD0_BYTES, return_pd0=False, headerid='\x7f\x7f',
 
         DATA.append(dd)
         cont+=1
-        if verbose and not cont%print_every:
-            print("Ensemble %d"%cont)
+        if verbose and not cont%print_every: print("Ensemble %d"%cont)
 
     errortype_count = dict(bad_checksum=nChecksumError,
                            read_checksum=nReadChecksumError,
                            read_header=nReadHeaderError)
 
+    # Extract ensemble-independent fields (store in xr.Dataset attributes).
+    # fixed_attrs = _pick_misc(DATA) # FIXME
+    fixed_attrs = []
 
     if return_pd0:
-        ret = (DATA, BAD_ENS, fbad_ens, errortype_count, PD0_BYTES)
+        ret = (DATA, fixed_attrs, BAD_ENS, fbad_ens, errortype_count, PD0_BYTES)
     else:
-        ret = (DATA, BAD_ENS, fbad_ens, errortype_count)
+        ret = (DATA, fixed_attrs, BAD_ENS, fbad_ens, errortype_count)
 
     return ret
 
 
-def read_PD0_bytes(pd0_bytes, return_pd0=False, format='workhorse'):
+def read_PD0_bytes(pd0_bytes, return_pd0=False, format='sentinel'):
     if format=='workhorse':
         data = parse_pd0_bytearray(pd0_bytes)
     elif format=='sentinel':
@@ -184,14 +325,106 @@ def read_PD0_bytes(pd0_bytes, return_pd0=False, format='workhorse'):
         print('Unknown *.pd0 format')
 
     if return_pd0:
-        return data, pd0_bytes
+        ret = data, pd0_bytes
     else:
-        return data
+        ret = data
+
+    return ret
 
 
 def inspect_PD0_file(path, format='sentinelV'):
     """
-    Fetches and organizes several metadata on instrument setup
+    Fetches and organizes metadata on instrument setup
     and organizes them in a table.
     """
     raise NotImplementedError()
+
+
+confparams = ['data_source', # START Header.
+              'number_of_bytes',
+              'address_offsets',
+              'number_of_data_types', # END Header.
+              'system_power',         # START fixed_leader_janus.
+              'system_configuration_MSB',
+              'sensor_source',
+              'system_configuration_LSB',
+              'system_bandwidth',
+              'number_of_cells',
+              'pings_per_ensemble',
+              'false_target_threshold',
+              'serial_number',
+              'lag_length',
+              'sensor_available',
+              'depth_cell_length',
+              'beam_angle',
+              'error_velocity_threshold',
+              'coordinate_transformation_process',
+              'heading_bias',
+              'transmit_pulse_length',
+              'heading_alignment',
+              'starting_depth_cell',
+              'number_of_beams',
+              'low_correlation_threshold',
+              'simulation_data_flag',
+              'cpu_firmware_version',
+              'transmit_lag_distance',
+              'ending_depth_cell',
+              'minimum_percentage_water_profile_pings',
+              'signal_processing_mode',
+              'blank_after_transmit',
+              'bin_1_distance',    # END fixed_leader_janus.
+              'depth_cell_length', # START fixed_leader_beam5.
+              'vertical_mode',
+              'ping_offset_time',
+              'vertical_lag_length',
+              'transmit_pulse_length',
+              'number_of_cells',
+              'bin_1_distance',
+              'transmit_code_elements',
+              'pings_per_ensemble',      # END fixed_leader_beam5.
+              'roll_standard_deviation', # START variable_leader_janus.
+              'error_status_word',
+              'attitude',
+              'contamination_sensor',
+              'attitude_temperature',
+              'temperature',
+              'speed_of_sound',
+              'pitch_standard_deviation',
+              'pressure_variance',
+              'heading_standard_deviation',
+              'pressure',
+              'transmit_current',
+              'ensemble_roll_over',
+              'depth_of_transducer',
+              'bit_result',
+              'ambient_temperature',
+              'salinity',
+              'pressure_positive',
+              'pressure_negative',
+              'transmit_voltage', # END variable_leader_janus.
+              ]
+
+
+def _pick_misc(d, confparams=confparams):
+    """
+    Check whether the configuration parameters change over ensembles.
+    If not, replace them with a single value.
+    """
+    dconfparams = dict()
+    d.reverse()
+    while d:
+        dn = d.pop()
+        for group in dn.keys():
+            for param in dn[group].keys():
+                if param in confparams:
+                    dconfparams.update({param:dconfparams[param].extend(dn[group][param])})
+
+    ddesc = np.unique([dnn['descriptors'] for dnn in d if dnn is not None]) # Array of lists.
+
+    if ddesc.size==1: # If all the lists store the exact same strings.
+        dconfparams['descriptors'] = ddesc
+    else:
+        # print("Warning: Some setup parameters changed during deployment.")
+        pass
+
+    return dconfparams

--- a/trdi_adcp_readers/readers.py
+++ b/trdi_adcp_readers/readers.py
@@ -1,9 +1,9 @@
-
 from trdi_adcp_readers.pd15.pd0_converters import (
     PD15_file_to_PD0,
     PD15_string_to_PD0
 )
 from trdi_adcp_readers.pd0.pd0_parser import parse_pd0_bytearray
+from trdi_adcp_readers.pd0.pd0_parser_sentinelV import parse_sentinelVpd0_bytearray
 
 
 def read_PD15_file(path, header_lines=0, return_pd0=False):
@@ -42,15 +42,23 @@ def read_PD0_file(path, header_lines=0, return_pd0=False):
 
         pd0_bytes = bytearray(f.read())
 
-    data = parse_pd0_bytearray(pd0_bytes)
+    if format=='workhorse':
+        data = parse_pd0_bytearray(pd0_bytes)
+    elif format='sentinelV':
+        data = parse_sentinelVpd0_bytearray(pd0_bytes)
+
     if return_pd0:
         return data, pd0_bytes
     else:
         return data
 
 
-def read_PD0_bytes(pd0_bytes, return_pd0=False):
-    data = parse_pd0_bytearray(pd0_bytes)
+def read_PD0_bytes(pd0_bytes, return_pd0=False, format='workhorse'):
+    if format=='workhorse':
+        data = parse_pd0_bytearray(pd0_bytes)
+    elif format='sentinelV':
+        data = parse_sentinelVpd0_bytearray(pd0_bytes)
+
     if return_pd0:
         return data, pd0_bytes
     else:

--- a/trdi_adcp_readers/readers.py
+++ b/trdi_adcp_readers/readers.py
@@ -1,7 +1,9 @@
 import numpy as np
-import dask.array as da
+import dask.array as darr
+from dask import compute, delayed
+from dask.bag import from_delayed
 from pandas import Timedelta
-from xarray import IndexVariable, DataArray, Dataset
+from xarray import Variable, IndexVariable, DataArray, Dataset
 from trdi_adcp_readers.pd0.pd0_parser_sentinelV import (ChecksumError,
                                                         ReadChecksumError,
                                                         ReadHeaderError)
@@ -42,6 +44,236 @@ def read_PD15_string(string, return_pd0=False):
         return data
 
 
+def _alloc_timestamp(item):
+    if type(item)==dict:
+        return item['timestamp']
+    else:
+        return item # NaNs marking bad ensembles.
+
+
+def _alloc_timestamp_parts(part): # Each partition is an array of dicts.
+    return np.array([ens['timestamp'] for ens in part if type(ens)==dict]) # Exclude NaNs marking bad ensembles.
+
+
+@delayed
+def _addtarr(t, dt):
+    return np.array([tn + dt for tn in t])
+
+
+def _alloc_1dvar(ensblk, group='variable_leader_janus', varname=''):
+    arrs = []
+    for ensarr in ensblk:
+        if type(ensarr)==dict:
+            arrs.append(ensarr[group][varname])
+        else:
+            continue
+
+    return darr.array(arrs)
+
+
+# def alloc_2dvars(ensarr):
+#         vjanus = ensarr['velocity_janus']['data']
+#         b1[:, n] = vjanus[:, 0]
+#         b2[:, n] = vjanus[:, 1]
+#         b3[:, n] = vjanus[:, 2]
+#         b4[:, n] = vjanus[:, 3]
+#         # b5[:, n] = ensarr['velocity_beam5']['data'].squeeze()
+#         # corjanus = ensarr['correlation_janus']['data']
+#         # cor1[:, n] = corjanus[:, 0]
+#         # cor2[:, n] = corjanus[:, 1]
+#         # cor3[:, n] = corjanus[:, 2]
+#         # cor4[:, n] = corjanus[:, 3]
+#         # cor5[:, n] = ensarr['correlation_beam5']['data'].squeeze()
+#         # intjanus = ensarr['echo_intensity_janus']['data']
+#         # int1[:, n] = intjanus[:, 0]
+#         # int2[:, n] = intjanus[:, 1]
+#         # int3[:, n] = intjanus[:, 2]
+#         # int4[:, n] = intjanus[:, 3]
+#         # int5[:, n] = ensarr['echo_intensity_beam5']['data'].squeeze()
+
+
+def ensembles2dataset_dask(ensdict, ncfpath, dsattrs={}, chunks=10,
+                           verbose=True, print_every=1000):
+    """
+    Convert a dictionary of ensembles into an xarray Dataset object
+    using dask.delayed to keep memory usage feasible.
+    """
+    mms2ms = 1e-3
+    n=0
+    ensdict_aux = ensdict[0].compute()
+    # fbadens = np.array(ensdict_aux)==None
+    # nt = len(ensdict) - np.sum(fbadens)
+
+    ensdict0 = None
+    while ensdict0 is None:
+        ensdict0 = ensdict_aux[n]
+        n+=1
+    nz = ensdict0['fixed_leader_janus']['number_of_cells']
+
+    fixj = ensdict0['fixed_leader_janus']
+    fix5 = ensdict0['fixed_leader_beam5']
+
+    # Add ping offset to get beam 5's timestamps.
+    dt5 = fix5['ping_offset_time'] # In milliseconds.
+    dt5 = np.array(Timedelta(dt5, unit='ms'))
+
+    th = fixj['beam_angle']
+    assert th==25 # Always 25 degrees.
+    th = th*np.pi/180.
+    Cth = np.cos(th)
+
+    # Scale heading, pitch and roll by 0.01. Sentinel V manual, p. 259.
+    phisc = 0.01
+    # Construct along-beam/vertical axes.
+    cm2m = 1e-2
+    r1janus = fixj['bin_1_distance']*cm2m
+    r1b5 = fix5['bin_1_distance']*cm2m
+    ncj = fixj['number_of_cells']
+    nc5 = fix5['number_of_cells']
+    lcj = fixj['depth_cell_length']*cm2m
+    lc5 = fix5['depth_cell_length']*cm2m
+    Lj = ncj*lcj # Distance from center of bin 1 to the center of last bin (Janus).
+    L5 = nc5*lc5 # Distance from center of bin 1 to the center of last bin (beam 5).
+
+    rb = r1janus + np.arange(0, Lj, lcj) # Distance from xducer head
+                                         # (Janus).
+    zab = Cth*rb                         # Vertical distance from xducer head
+                                         # (Janus).
+    zab5 = r1b5 + np.arange(0, L5, lc5)  # Distance from xducer head, also
+                                         # depth for the vertical beam.
+
+    rb = IndexVariable('z', rb, attrs={'units':'meters', 'long_name':"along-beam distance from the xducer's face to the center of the bins, for beams 1-4 (Janus)"})
+    zab = IndexVariable('z', zab, attrs={'units':'meters', 'long_name':"vertical distance from the instrument's head to the center of the bins, for beams 1-4 (Janus)"})
+    zab5 = IndexVariable('z', zab5, attrs={'units':'meters', 'long_name':"vertical distance from xducer face to the center of the bins, for beam 5 (vertical)"})
+
+    ensdict = from_delayed(ensdict)
+    tjanus = ensdict.map_partitions(_alloc_timestamp_parts)
+    t5 = _addtarr(tjanus, dt5)
+
+    if verbose: print("Unpacking timestamps.")
+    time = IndexVariable('time', tjanus.compute(), attrs={'long_name':'timestamps for beams 1-4 (Janus)'})
+    time5 = IndexVariable('time5', t5.compute(), attrs={'long_name':'timestamps for beam 5 (vertical)'})
+    if verbose: print("Done unpacking timestamps.")
+
+    coords0 = [('time', time)]
+    coords = [('z', zab), ('time', time)]
+    coords5 = [('z5', zab5), ('time5', time5)]
+    dims = ['z', 'time']
+    dims0 = ['time']
+    coordsdict = dict(time=('time', time))
+
+    # Load 1d variables into memory to
+    # be able to put them in a DataArray.
+    # Heading, pitch and roll first.
+    vars1d = dict()
+    if verbose: print("Saving 1D variables.")
+    for varname in ['heading', 'pitch', 'roll']:
+        aux = ensdict.map_partitions(_alloc_1dvar, group='variable_leader_janus', varname=varname)
+        vars1d.update({varname:DataArray(np.array(aux.compute())*phisc, coords=coords0, dims=dims0, attrs=dict(units='degrees'))})
+
+    # Open an xarray.Dataset in delayed mode and
+    # save 1D variables in a single compute cycle.
+    if verbose: print("Opening netCDF file: %s"%ncfpath)
+    ds1d = Dataset(data_vars=vars1d, coords=coordsdict)
+    ds1d = ds1d.to_netcdf(ncfpath, compute=False, mode='w')
+    ds1d.compute()
+    if verbose: print("Done saving 1D variables.")
+    embed()
+
+    # Load 2d variables into memory to
+    # be able to put them in a DataArray.
+    # coordsdict = dict(z=('z', zab), time=('time', time))
+
+
+    # ds2d = Dataset(data_vars=vars2d, coords=coordsdict)
+    # ds2d = ds2d.to_netcdf(ncfpath, compute=False, mode='a')
+    # ds2d.compute()
+
+
+
+
+
+
+    long_names = ('Beam 1 velocity', 'Beam 2 velocity',
+             'Beam 3 velocity', 'Beam 4 velocity',
+             'Beam 5 velocity',
+             'Beam 1 correlation', 'Beam 2 correlation',
+             'Beam 3 correlation', 'Beam 4 correlation',
+             'Beam 5 correlation',
+             'Beam 1 echo amplitude', 'Beam 2 echo amplitude',
+             'Beam 3 echo amplitude', 'Beam 4 echo amplitude',
+             'Beam 5 echo amplitude',
+             'heading', 'pitch', 'roll')
+    units = ('m/s, positive toward xducer face',
+             'm/s, positive toward xducer face',
+             'm/s, positive toward xducer face',
+             'm/s, positive toward xducer face',
+             'm/s, positive toward xducer face',
+             'no units', 'no units', 'no units', 'no units',
+             'no units',
+             'decibels', 'decibels', 'decibels', 'decibels',
+             'decibels',
+             'degrees', 'degrees', 'degrees')
+    names = ('b1', 'b2', 'b3', 'b4', 'b5',
+             'cor1', 'cor2', 'cor3', 'cor4', 'cor5',
+             'int1', 'int2', 'int3', 'int4', 'int5',
+             'phi1', 'phi2', 'phi3')
+    # data_vars = {}
+
+
+    #
+    # sk = darr.zeros((nz, nt), chunks=chunks)*np.nan # Beam vels stored in mm/s
+    #                                   # as int64 to save memory.
+    # b1, b2, b3, b4 = sk.copy(), sk.copy(), sk.copy(), sk.copy()
+    # # embed()
+    # sk0 = darr.zeros(nt, chunks=chunks)*np.nan
+    # cor1, cor2, cor3, cor4 = sk.copy(), sk.copy(), sk.copy(), sk.copy()
+    # int1, int2, int3, int4 = sk.copy(), sk.copy(), sk.copy(), sk.copy()
+    # b5, cor5, int5 = sk.copy(), sk.copy(), sk.copy()
+    # heading, pitch, roll = sk0.copy(), sk0.copy(), sk0.copy()
+    # tjanus = []
+
+    # ensdict = np.array(ensdict)[~fbadens]
+    # ensdict = ensdict.tolist()
+
+    # Convert velocities to m/s.
+    # b1, b2, b3, b4, b5 = b1*mms2ms, b2*mms2ms, b3*mms2ms, b4*mms2ms, b5*mms2ms
+
+    # Scale heading, pitch and roll. Sentinel V manual, p. 259.
+
+    heading *= phisc
+    pitch *= phisc
+    roll *= phisc
+
+    arrs = (b1, b2, b3, b4, b5,
+            cor1, cor2, cor3, cor4, cor5,
+            int1, int2, int3, int4, int5,
+            heading, pitch, roll)
+            # pressure, temperature, salinity, soundspeed)
+
+    for arr,name,long_name,unit in zip(arrs,names,long_names,units):
+
+        if 'Beam5' in long_name:
+            coordsn = coords5
+            dimsn = dims
+        elif 'phi' in name:
+            coordsn = coords0
+            dimsn = dims0
+        else:
+            coordsn = coords
+            dimsn = dims
+
+        da = DataArray(arr, coords=coordsn, dims=dimsn, attrs=dict(units=unit, long_name=long_name))
+        data_vars.update({name:da})
+
+    allcoords = {'rb':rb} # Along-beam distance for slanted beams.
+    allcoords.update(coords)
+    allcoords.update(coords5)
+    ds = Dataset(data_vars=data_vars, coords=allcoords, attrs=dsattrs)
+
+    return ds
+
+
 def ensembles2dataset(ensdict, dsattrs={}, verbose=False, print_every=1000):
     """
     Convert a dictionary of ensembles into an xarray Dataset object.
@@ -59,7 +291,6 @@ def ensembles2dataset(ensdict, dsattrs={}, verbose=False, print_every=1000):
                                       # as int64 to save memory.
     b1, b2, b3, b4 = sk.copy(), sk.copy(), sk.copy(), sk.copy()
     sk0 = np.ma.zeros(nt)*np.nan
-    skt = np.ma.zeros(nt, dtype=object)*np.nan
     cor1, cor2, cor3, cor4 = sk.copy(), sk.copy(), sk.copy(), sk.copy()
     int1, int2, int3, int4 = sk.copy(), sk.copy(), sk.copy(), sk.copy()
     b5, cor5, int5 = sk.copy(), sk.copy(), sk.copy()
@@ -225,7 +456,7 @@ def read_PD0_file(path, header_lines=0, return_pd0=False, all_ensembles=True,
         data, t, fixed_attrs, BAD_ENS, fbad_ens, errortype_count = ret
 
     if verbose:
-        nens = len(data)
+        nens = len(t)
         nbadens = len(fbad_ens)
         ngoodens = nens - nbadens
         pbadens = 100.*nbadens/nens
@@ -282,14 +513,15 @@ def read_PD0_bytes_ensembles(PD0_BYTES, return_pd0=False, headerid='\x7f\x7f',
     t = np.empty(nens, dtype=object)
 
     if use_dask:
-        DATA = da.empty(nens, chunks=chunks)
+        DATA = []
+        # DATA = darr.empty(nens, chunks=chunks)
         ntotalchunks = nens//chunks
         rem_ens = nens%chunks
         has_tail=rem_ens>0
         if has_tail: ntotalchunks+=1 # Last chunk takes remaining ensembles.
         DATAbuffskel = np.empty(chunks, dtype=object)
         DATAbuff = DATAbuffskel.copy()
-        daNaN = da.array(np.array(np.nan, ndmin=1))
+        daNaN = darr.array(np.array(np.nan, ndmin=1))
         cont_inchnk=0
     else:
         DATA = np.empty(nens, dtype=object)
@@ -317,14 +549,16 @@ def read_PD0_bytes_ensembles(PD0_BYTES, return_pd0=False, headerid='\x7f\x7f',
 
             if use_dask:
                 if cont_inchnk==chunks:
-                    DATA = da.concatenate((DATA, daNaN.copy()))
+                    # DATA = darr.concatenate((DATA, daNaN.copy()))
+                    DATA.append(delayed(daNaN.copy()))
                     DATAbuff = DATAbuffskel.copy()
                     cont_inchnk=0
                 else:
                     DATAbuff[cont_inchnk] = np.nan
                     cont_inchnk+=1
                     if has_tail and cont==nensm: # Save the last chunk.
-                        DATA = da.concatenate((DATA, daNaN.copy()))
+                        # DATA = darr.concatenate((DATA, daNaN.copy()))
+                        DATA.append(delayed(daNaN.copy()))
             else:
                 DATA[cont] = np.nan
 
@@ -333,14 +567,16 @@ def read_PD0_bytes_ensembles(PD0_BYTES, return_pd0=False, headerid='\x7f\x7f',
 
         if use_dask:
             if cont_inchnk==chunks:
-                DATA = da.concatenate((DATA, da.array(DATAbuff)))
+                # DATA = darr.concatenate((DATA, darr.array(DATAbuff)))
+                DATA.append(delayed(DATAbuff))
                 DATAbuff = DATAbuffskel.copy()
                 cont_inchnk=0
+                # embed()
             else:
                 DATAbuff[cont_inchnk] = dd
                 cont_inchnk+=1
                 if has_tail and cont==nensm: # Save the last chunk.
-                    DATA = da.concatenate((DATA, da.array(DATAbuff)))
+                    DATA.append(delayed(DATAbuff))
         else:
             DATA[cont] = dd
 
@@ -354,6 +590,7 @@ def read_PD0_bytes_ensembles(PD0_BYTES, return_pd0=False, headerid='\x7f\x7f',
     # Extract ensemble-independent fields (store in xr.Dataset attributes).
     # fixed_attrs = _pick_misc(DATA) # FIXME
     fixed_attrs = []
+    # embed()
 
     if return_pd0:
         ret = (DATA, t, fixed_attrs, BAD_ENS, fbad_ens, errortype_count, PD0_BYTES)

--- a/trdi_adcp_readers/readers.py
+++ b/trdi_adcp_readers/readers.py
@@ -1,10 +1,14 @@
 import numpy as np
+from trdi_adcp_readers.pd0.pd0_parser_sentinelV import (ChecksumError,
+                                                        ReadChecksumError,
+                                                        ReadHeaderError)
 from trdi_adcp_readers.pd15.pd0_converters import (
     PD15_file_to_PD0,
     PD15_string_to_PD0
 )
 from trdi_adcp_readers.pd0.pd0_parser import parse_pd0_bytearray
 from trdi_adcp_readers.pd0.pd0_parser_sentinelV import parse_sentinelVpd0_bytearray
+from IPython import embed
 
 
 def read_PD15_file(path, header_lines=0, return_pd0=False):
@@ -35,33 +39,84 @@ def read_PD15_string(string, return_pd0=False):
         return data
 
 
+def ensdict2xarray(ensdict):
+    """
+    Convert a dictionary of ensembles into an xarray Dataset object.
+    """
+    fbadens = np.array(ensdict)==None
+    nt = len(ensdict) - np.sum(fbadens)
+    nz = ensdict[0]['fixed_leader_janus']['number_of_cells']
+    sk = np.ma.ones((nz, nt)) # Beam vels stored in mm/s
+                                              # as int64 to save memory.
+    b5 = sk.copy()
+    ensdict = np.array(ensdict)[~fbadens]
+    ensdict = ensdict.tolist()
+    n=0
+    for ensarr in ensdict:
+        b5[:, n] = ensarr['velocity_beam5']['data'].squeeze()
+        if not n%1000: print(n)
+        n+=1
+
+    return b5
+
+
 def read_PD0_file(path, header_lines=0, return_pd0=False, all_ensembles=True,
-                  format='workhorse'):
+                  format='sentinel', debug=False, verbose=True):
+    """Read a TRDI Workhorse or Sentinel V *.pd0 file."""
     pd0_bytes = bytearray()
     with open(path, 'rb') as f:
         pd0_bytes = bytearray(f.read())
+    f.close()
 
     if all_ensembles:
         pd0reader = read_PD0_bytes_ensembles
+        kwread = dict(verbose=verbose)
     else:
         pd0reader = read_PD0_bytes
+        kwread = dict()
 
-    data = pd0reader(pd0_bytes, return_pd0=return_pd0,
-                     format=format)
+    ret = pd0reader(pd0_bytes, return_pd0=return_pd0, format=format, **kwread)
+
+    if return_pd0:
+        data, BAD_ENS, fbad_ens, errortype_count, pd0_bytes = ret
+    else:
+        data, BAD_ENS, fbad_ens, errortype_count = ret
+
+    if verbose:
+        nens = len(data)
+        nbadens = len(fbad_ens)
+        ngoodens = nens - nbadens
+        pbadens = 100.*nbadens/nens
+        print("")
+        print("Skipped  %d/%d  bad ensembles (%.2f%%)."%(nbadens, nens, pbadens))
+        print("---Breakdown of dud ensembles---")
+        print("*Bad checksums:  %d"%errortype_count['bad_checksum'])
+        print("*Could not read ensemble's checksum:  %d"%errortype_count['read_checksum'])
+        print("*Could not read ensemble's header:  %d"%errortype_count['read_header'])
 
     # Get timestamps for all ensembles.
     # Note that these timestamps indicate the Janus' (i.e., beams 1-4) pings,
     # which will not necessarily be the same as the vertical beam's timestamp.
-    t = np.array([data[n]['timestamp'] for n in xrange(len(data))])
+    t = np.array([ens['timestamp'] for ens in data if ens is not None])
+    # t5 = np.array([ens['timestamp5'] for ens in data if ens is not None])
 
-    if return_pd0:
-        return data, t, pd0_bytes
+    if debug:
+        if return_pd0:
+            ret = data, t, BAD_ENS, fbad_ens, errortype_count, pd0_bytes
+        else:
+            ret = data, t, BAD_ENS, fbad_ens, errortype_count
     else:
-        return data, t
+        if return_pd0:
+            ret = data, t, pd0_bytes
+        else:
+            ret = data, t
+
+    return ret
 
 
 def read_PD0_bytes_ensembles(PD0_BYTES, return_pd0=False, headerid='\x7f\x7f',
-                             format='workhorse'):
+                             format='workhorse',
+                             verbose=True, print_every=1000):
     """
     Finds the hex positions in the bytearray that identify the header of each
     ensemble. Then read each ensemble into a dictionary and accumulates them
@@ -79,12 +134,45 @@ def read_PD0_bytes_ensembles(PD0_BYTES, return_pd0=False, headerid='\x7f\x7f',
     ensbytes = PD0_BYTES.split(headerid)
     ensbytes = [headerid + ens for ens in ensbytes] # Prepend header id back.
     ensbytes = ensbytes[1:] # First entry is empty, cap it off.
-    _ = [DATA.append(parsepd0(ensb)) for ensb in ensbytes]
+    cont=0
+    fbad_ens = []
+    BAD_ENS = []
+    nChecksumError, nReadChecksumError, nReadHeaderError = 0, 0, 0
+    for ensb in ensbytes:
+        try:
+            dd = parsepd0(ensb)
+        except (ChecksumError, ReadChecksumError, ReadHeaderError) as E:
+            fbad_ens.append(cont) # Store index of bad ensemble.
+            BAD_ENS.append(ens)   # Store bytes of the bad ensemble.
+
+            # Which type of error was it?
+            if isinstance(E, ChecksumError):
+                nChecksumError += 1
+            elif isinstance(E, ReadChecksumError):
+                nReadChecksumError += 1
+            elif isinstance(E, ReadHeaderError):
+                nReadHeaderError += 1
+
+            DATA.append(None)
+            cont+=1
+            continue
+
+        DATA.append(dd)
+        cont+=1
+        if verbose and not cont%print_every:
+            print("Ensemble %d"%cont)
+
+    errortype_count = dict(bad_checksum=nChecksumError,
+                           read_checksum=nReadChecksumError,
+                           read_header=nReadHeaderError)
+
 
     if return_pd0:
-        return DATA, PD0_BYTES
+        ret = (DATA, BAD_ENS, fbad_ens, errortype_count, PD0_BYTES)
     else:
-        return DATA
+        ret = (DATA, BAD_ENS, fbad_ens, errortype_count)
+
+    return ret
 
 
 def read_PD0_bytes(pd0_bytes, return_pd0=False, format='workhorse'):
@@ -99,6 +187,7 @@ def read_PD0_bytes(pd0_bytes, return_pd0=False, format='workhorse'):
         return data, pd0_bytes
     else:
         return data
+
 
 def inspect_PD0_file(path, format='sentinelV'):
     """

--- a/trdi_adcp_readers/readers.py
+++ b/trdi_adcp_readers/readers.py
@@ -211,8 +211,8 @@ def ensembles2dataset_dask(ensdict, ncfpath, dsattrs={}, chunks=10,
              'm/s, positive toward xducer face',
              'no units', 'no units', 'no units', 'no units',
              'no units',
-             'decibels', 'decibels', 'decibels', 'decibels',
-             'decibels',
+             'dB', 'dB', 'dB', 'dB',
+             'dB',
              'degrees', 'degrees', 'degrees')
     names = ('b1', 'b2', 'b3', 'b4', 'b5',
              'cor1', 'cor2', 'cor3', 'cor4', 'cor5',
@@ -279,7 +279,7 @@ def ensembles2dataset(ensdict, dsattrs={}, verbose=False, print_every=1000):
     Convert a dictionary of ensembles into an xarray Dataset object.
     """
     mms2ms = 1e-3
-    fbadens = np.array(ensdict)==None
+    fbadens = np.array([not isinstance(ens, dict) for ens in ensdict])
     nt = len(ensdict) - np.sum(fbadens)
     n=0
     ensdict0 = None
@@ -401,8 +401,8 @@ def ensembles2dataset(ensdict, dsattrs={}, verbose=False, print_every=1000):
              'm/s, positive toward xducer face',
              'no units', 'no units', 'no units', 'no units',
              'no units',
-             'decibels', 'decibels', 'decibels', 'decibels',
-             'decibels',
+             'dB', 'dB', 'dB', 'dB',
+             'dB',
              'degrees', 'degrees', 'degrees')
     names = ('b1', 'b2', 'b3', 'b4', 'b5',
              'cor1', 'cor2', 'cor3', 'cor4', 'cor5',
@@ -420,6 +420,10 @@ def ensembles2dataset(ensdict, dsattrs={}, verbose=False, print_every=1000):
         else:
             coordsn = coords
             dimsn = dims
+
+        if 'int' in name:
+            arr *= 0.45 # Scale factor for echo intensity, see Sentinel V manual
+                        # Sentinel V manual p. 264.
 
         da = DataArray(arr, coords=coordsn, dims=dimsn, attrs=dict(units=unit, long_name=long_name))
         data_vars.update({name:da})


### PR DESCRIPTION
Adding support for the *.pd0 format generated by the Sentinel V model.

I've copied the `pd0.pd0_parser` submodule and adapted it following TRDI's manual for the Sentinel V. The new submodule is `pd0.pd0_parser_sentinelV`.

Also added some messages that are printed when bad ensembles are skipped, and new functions to read all ensembles in a file and convert the output to an `xarray.Dataset` object with some metadata. So we can parse a *.pd0 file and readily save it as a netCDF file with the method `.to_netcdf('filename.nc')`.